### PR TITLE
fix: resolve configurations path from executable location

### DIFF
--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -15,7 +15,20 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var ConfigurationsRelativeFilePath = "./configurations"
+var ConfigurationsRelativeFilePath = resolveConfigurationsPath()
+
+// resolveConfigurationsPath returns the configurations directory path relative to the executable location.
+func resolveConfigurationsPath() string {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "./configurations"
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return "./configurations"
+	}
+	return filepath.Join(filepath.Dir(execPath), "configurations")
+}
 var ConfigurationsRelativeFileExtension = ".yaml"
 
 const VariablePlaceHolderPrefix = "$"


### PR DESCRIPTION
## Fix: Resolve configurations path from executable location

### Problem

When `aws-commander` is installed via Homebrew (`brew install aws-commander`), running the binary from any directory other than the project root fails with:

```
open ./configurations: no such file or directory
```

This happens because `ConfigurationsRelativeFilePath` was hardcoded as `"./configurations"`, which resolves against the **current working directory** instead of the binary's location.

### Solution

Replaced the hardcoded relative path with `resolveConfigurationsPath()`, which uses `os.Executable()` + `filepath.EvalSymlinks()` to locate the `configurations/` directory next to the actual binary. This handles both direct execution and Homebrew's symlink layout (`bin/` → `Cellar/`). Falls back to `"./configurations"` if resolution fails.

### Local Testing (Run from the aws-commander folder to build it)

**1. Reproduce the bug:**
```bash
mkdir -p /tmp/aws-commander-test
go build -o /tmp/aws-commander-test/aws-commander .
cd /tmp && /tmp/aws-commander-test/aws-commander
# ❌ open ./configurations: no such file or directory
```

**2. Apply fix and test with configurations next to binary:**
```bash
go build -o /tmp/aws-commander-test/aws-commander .
cp -r configurations /tmp/aws-commander-test/
cd /tmp && /tmp/aws-commander-test/aws-commander
# ✅ TUI launches successfully
```

**3. Test symlink scenario (simulates Homebrew layout):**
```bash
mkdir -p /tmp/aws-commander-symtest
ln -sf /tmp/aws-commander-test/aws-commander /tmp/aws-commander-symtest/aws-commander
cd /tmp && /tmp/aws-commander-symtest/aws-commander
# ✅ Resolves through symlink, finds configurations next to real binary
```

**4. Verify existing tests:**
```bash
go build ./... && go vet ./... && go test ./...
# ✅ All tests pass
```
