### PR TITLE
feat: add SNS service support with topic and subscription commands

### DIFF
--- a/configurations/sns.yaml
+++ b/configurations/sns.yaml
@@ -1,0 +1,78 @@
+name: "sns"
+defaultCommand: "list-topics"
+commands:
+  - name: "list-topics"
+    resourceName: topicArn
+    rerunOnBack: false
+    favouritable: true
+    arguments:
+      - "--output"
+      - "json"
+      - "--cli-read-timeout"
+      - "10"
+      - "--cli-connect-timeout"
+      - "5"
+    view: tableView
+    parse:
+      type: "object"
+      attributeName: "Topics"
+    pagination:
+      enabled: true
+      nextTokenParam: "--next-token"
+      nextTokenJsonPath: "NextToken"
+  - name: "list-subscriptions-by-topic"
+    depends_on: "list-topics"
+    resourceName: subscriptionArn
+    rerunOnBack: false
+    arguments:
+      - "--topic-arn"
+      - "$TOPICARN"
+      - "--output"
+      - "json"
+      - "--cli-read-timeout"
+      - "10"
+      - "--cli-connect-timeout"
+      - "5"
+    view: tableView
+    showJsonViewer: true
+    parse:
+      type: "object"
+      attributeName: "Subscriptions"
+    pagination:
+      enabled: true
+      nextTokenParam: "--next-token"
+      nextTokenJsonPath: "NextToken"
+  - name: "get-topic-attributes"
+    depends_on: "list-topics"
+    rerunOnBack: false
+    arguments:
+      - "--topic-arn"
+      - "$TOPICARN"
+      - "--output"
+      - "json"
+      - "--cli-read-timeout"
+      - "10"
+      - "--cli-connect-timeout"
+      - "5"
+    view: tableView
+    showJsonViewer: true
+    parse:
+      type: "keys"
+      attributeName: "Attributes"
+  - name: "get-subscription-attributes"
+    depends_on: "list-subscriptions-by-topic"
+    rerunOnBack: false
+    arguments:
+      - "--subscription-arn"
+      - "$SUBSCRIPTIONARN"
+      - "--output"
+      - "json"
+      - "--cli-read-timeout"
+      - "10"
+      - "--cli-connect-timeout"
+      - "5"
+    view: tableView
+    showJsonViewer: true
+    parse:
+      type: "keys"
+      attributeName: "Attributes"


### PR DESCRIPTION
## Summary

- Add SNS as a new supported AWS service
- List all SNS topics with pagination support
- View subscriptions for a selected topic with drill-down capability
- Get topic and subscription attributes

## Commands Added

| Command | Description |
|---------|-------------|
| `list-topics` | Lists all SNS topics (default command) |
| `list-subscriptions-by-topic` | Shows all subscriptions for a selected topic |
| `get-topic-attributes` | Displays topic configuration and metadata |
| `get-subscription-attributes` | Displays subscription configuration details |

## Navigation Flow

```
SNS Topics → Select Topic → View Subscriptions → Select Subscription → View Attributes
                         → View Topic Attributes
```

## Testing

- [x] Build succeeds (`go build ./...`)